### PR TITLE
single linters: Add regex linter.

### DIFF
--- a/git_lint_branch/linter_output.py
+++ b/git_lint_branch/linter_output.py
@@ -1,6 +1,6 @@
-from enum import Enum
+from enum import IntEnum
 
-class LinterLevel(Enum):
+class LinterLevel(IntEnum):
     """
     Linter output severity levels. Rough definitions:
     Notice: Likely not a problem, but worth noting.

--- a/git_lint_branch/single/__init__.py
+++ b/git_lint_branch/single/__init__.py
@@ -1,5 +1,9 @@
 from pygit2 import Commit
 from git_lint_branch.linter_output import *
 from git_lint_branch.single.linters import *
+from git_lint_branch.single.regex_linter import *
 
-single_linters = [example_linter]
+single_linters = [
+    example_linter,
+    regex_linter,
+]

--- a/git_lint_branch/single/regex_linter.py
+++ b/git_lint_branch/single/regex_linter.py
@@ -1,0 +1,47 @@
+import re
+
+from pygit2 import Commit
+from git_lint_branch.linter_output import *
+
+# TODO: Load from config
+REGEX = r'^(.+:\ )?[A-Z].+\.$'
+TITLE_LENGTH = 76
+BODY_LINE_LENGTH = 76
+
+def regex_linter(commit: Commit):
+    result = LinterOutput()
+
+    result.level = LinterLevel.Empty
+    result.title = 'Commit message format'
+    result.message = '''
+    '''
+    result.help_string = f'''
+    Make sure the commit message title follows this pattern: {REGEX}
+    and is under {TITLE_LENGTH} characters.
+
+    Also keep each line of the commit message body under {BODY_LINE_LENGTH} characters.
+    '''
+
+    pattern = re.compile(REGEX, re.UNICODE)
+    commit_title = commit.message.splitlines()[0]
+    if pattern.fullmatch(commit_title) is None:
+        result.level = LinterLevel.Warning
+        result.message += \
+        '''Commit title does not match pattern.
+    '''
+
+    if len(commit_title) > TITLE_LENGTH:
+        result.level = max(result.level, LinterLevel.Warning)
+        result.message += \
+        '''Commit title too long.
+    '''
+
+    for line in commit.message.splitlines()[1:]:
+        if len(line) > BODY_LINE_LENGTH:
+            result.level = max(result.level, LinterLevel.Notice)
+            result.message += \
+            '''Commit body lines too long.
+    '''
+            break
+
+    return result


### PR DESCRIPTION
### Sample output:
![image](https://user-images.githubusercontent.com/43912285/87475219-00b19280-c642-11ea-9537-688263de6e94.png)

### Checks for
- Commit title against a regex
- Length of the commit title
- Length of each line in the commit body

### Note:
- `LinterLevel` should inherit `IntEnum` to allow comparisons between levels.