### PR TITLE
single-commit linters: Add diff size linter

### DIFF
--- a/git_lint_branch/cfg.py
+++ b/git_lint_branch/cfg.py
@@ -1,0 +1,1 @@
+repo = None

--- a/git_lint_branch/main.py
+++ b/git_lint_branch/main.py
@@ -1,4 +1,6 @@
 import typer
+import os
+from pygit2 import discover_repository
 from pygit2 import Repository
 from pygit2 import GIT_SORT_TOPOLOGICAL
 from git_lint_branch.linter_output import *
@@ -12,7 +14,11 @@ def main(upstream: str):
     Lints the commit history reachable from the current HEAD that is not
     on UPSTREAM (i.e., the current branch).
     """
-    repo = Repository('.git')
+    repo_path = discover_repository(os.getcwd())
+    if repo_path is None:
+        typer.echo('fatal: not a git repository (or any of the parent directories)', err=True)
+        raise typer.Exit(code=1)
+    repo = Repository(repo_path)
     upstream = repo.revparse_single(upstream)
     walker = repo.walk(repo.head.target, GIT_SORT_TOPOLOGICAL)
     walker.hide(upstream.id)

--- a/git_lint_branch/main.py
+++ b/git_lint_branch/main.py
@@ -3,6 +3,7 @@ import os
 from pygit2 import discover_repository
 from pygit2 import Repository
 from pygit2 import GIT_SORT_TOPOLOGICAL
+import git_lint_branch.cfg as cfg
 from git_lint_branch.linter_output import *
 from git_lint_branch.single import single_linters
 
@@ -18,9 +19,9 @@ def main(upstream: str):
     if repo_path is None:
         typer.echo('fatal: not a git repository (or any of the parent directories)', err=True)
         raise typer.Exit(code=1)
-    repo = Repository(repo_path)
-    upstream = repo.revparse_single(upstream)
-    walker = repo.walk(repo.head.target, GIT_SORT_TOPOLOGICAL)
+    cfg.repo = Repository(repo_path)
+    upstream = cfg.repo.revparse_single(upstream)
+    walker = cfg.repo.walk(cfg.repo.head.target, GIT_SORT_TOPOLOGICAL)
     walker.hide(upstream.id)
     for commit in walker:
         for linter in single_linters:

--- a/git_lint_branch/single/__init__.py
+++ b/git_lint_branch/single/__init__.py
@@ -2,8 +2,10 @@ from pygit2 import Commit
 from git_lint_branch.linter_output import *
 from git_lint_branch.single.linters import *
 from git_lint_branch.single.regex_linter import *
+from git_lint_branch.single.diff_size_linter import diff_size_linter
 
 single_linters = [
     example_linter,
     regex_linter,
+    diff_size_linter,
 ]

--- a/git_lint_branch/single/diff_size_linter.py
+++ b/git_lint_branch/single/diff_size_linter.py
@@ -1,0 +1,48 @@
+from pygit2 import Commit, Diff
+
+from git_lint_branch.linter_output import *
+import git_lint_branch.cfg as cfg
+
+LARGE_DIFF_THRESHOLD = 50
+
+def guess_diff_size(diff: Diff):
+    '''
+    Uses max(insertions, deletions) per patch, summed over all patches
+    to determine the size of a diff. Based on the guess that unrelated
+    insertions and deletions may not commonly appear together. This prevents
+    modifications from being counted twice.
+    '''
+    diff_size = 0
+    for patch in diff:
+        diff_size += max(patch.line_stats[1], patch.line_stats[2])
+    return diff_size
+
+
+def diff_size_linter(commit: Commit):
+
+    result = LinterOutput()
+    result.title = 'Commit diff size'
+    result.level = LinterLevel.Empty
+    result.help_string = '''
+    A commit with a very large diff might contain unrelated changes.
+    Consider splitting these changes into multiple commits if they are
+    unrelated.
+    '''
+    
+    if len(commit.parents) != 1:
+        return result
+        # reached a merge commit or the initial commit, don't check it
+
+    diff = cfg.repo.diff(commit, commit.parents[0])
+    diff_size = guess_diff_size(diff)
+
+    if diff_size > LARGE_DIFF_THRESHOLD:
+        result.level = LinterLevel.Caution
+        result.message = f'''
+    This commit has a large diff (~{diff_size} modifications).
+    '''
+
+    return result
+
+        
+     


### PR DESCRIPTION
Passes the repo and upstream objects to each multiple-commit linter, letting them handle everything else on their own.

## Large diff linter sample:
![image](https://user-images.githubusercontent.com/43912285/87541346-bae6df80-c6be-11ea-838d-ddcd1e4dce82.png)
