### PR TITLE
Beautify

### DIFF
--- a/git_lint_branch/linter_output.py
+++ b/git_lint_branch/linter_output.py
@@ -1,13 +1,5 @@
-from git_lint_branch.colors import colorize
 from enum import IntEnum
-
-linterlevel2color = dict(
-    Empty='white',
-    Notice='blue',
-    Caution='cyan',
-    Warning='yellow',
-    Failure='red',
-)
+import typer
 
 class LinterLevel(IntEnum):
     """
@@ -23,6 +15,14 @@ class LinterLevel(IntEnum):
     Caution = 2
     Warning = 3
     Failure = 4
+
+color_map = {
+    LinterLevel.Empty: typer.colors.WHITE,
+    LinterLevel.Notice: typer.colors.BLUE,
+    LinterLevel.Caution: typer.colors.GREEN,
+    LinterLevel.Warning: typer.colors.YELLOW,
+    LinterLevel.Failure: typer.colors.RED,
+}
 
 class LinterOutput():
     @property
@@ -62,16 +62,24 @@ class LinterOutput():
     def help_string(self, value: str):
         self._help_string = value
 
-    def pretty_print(self):
-        if self._level is LinterLevel.Empty:
+    def pretty_str(self, verbose: bool = True):
+        if self.level is LinterLevel.Empty:
             raise ValueError('Cannot pretty print an empty LinterOutput')
-        print(
-            colorize(
-                'Severity: {level}'.format(level=self.level.name),
-                color=linterlevel2color[self.level.name],
-                bold=True
-            )
-        )
-        print(self.title)
-        print('Details:\n{message}'.format(message=self.message))
-        print('Suggestions:\n{help_string}'.format(help_string=self.help_string))
+        
+        out = typer.style('\n+ ', fg=typer.colors.MAGENTA)
+        out += typer.style('FAULT: ', fg=typer.colors.BRIGHT_MAGENTA)
+        out += typer.style(self.title, fg=typer.colors.BRIGHT_MAGENTA, bold=True)
+        
+        out += typer.style('\n  SEVERITY: ', fg=typer.colors.BRIGHT_MAGENTA)
+        out += typer.style(self.level.name, fg=color_map[self.level], bold=True)
+
+        out += typer.style('\n  DETAILS:\n', fg=typer.colors.BRIGHT_MAGENTA)
+        out += typer.style(self.message, fg=typer.colors.WHITE)
+        
+        if verbose:
+
+            out += typer.style('\n  SUGGESTIONS:\n', fg=typer.colors.BRIGHT_MAGENTA)
+            out += typer.style(self.help_string, fg=typer.colors.WHITE)
+        
+        return out
+

--- a/git_lint_branch/main.py
+++ b/git_lint_branch/main.py
@@ -2,7 +2,7 @@ import typer
 import os
 from pygit2 import discover_repository
 import collections
-from pygit2 import Repository
+from pygit2 import Repository, Commit
 from pygit2 import GIT_SORT_TOPOLOGICAL
 import git_lint_branch.cfg as cfg
 from git_lint_branch.linter_output import *
@@ -23,6 +23,46 @@ def tosequence(it):
         it = list(it)
     return it
 
+class Printer:
+    def __init__(self, verbose: bool = True):
+        # self._single_data = typer.style('+++ ', fg=typer.colors.CYAN)
+        # self._single_data += typer.style('Linting your commits:\n', fg=typer.colors.BRIGHT_CYAN, bold=True, underline=True)
+        self._verbose = verbose
+        
+        self._single_data = ''
+        self._commit_str = ''
+
+        self._multiple_data = ''
+
+    def add_commit(self, commit: Commit):
+        self._commit_str = typer.style(f'\nCOMMIT: {commit.id}\n', fg=typer.colors.BRIGHT_CYAN, bold=True)
+        self._commit_str += typer.style(f'TITLE: {commit.message.splitlines()[0]}\n', fg=typer.colors.BRIGHT_CYAN, bold=True)
+
+    def add_single_linter(self, linter: LinterOutput):
+        self._single_data += self._commit_str
+        self._commit_str = ''
+
+        self._single_data += linter.pretty_str(self._verbose)
+
+    def add_multiple_linter(self, linter: LinterOutput):
+        self._multiple_data += linter.pretty_str(self._verbose)
+        
+    def show(self):
+        final_str = ''
+        if len(self._single_data) > 0:
+            final_str += typer.style('+++ ', fg=typer.colors.GREEN)
+            final_str += typer.style('Linting your commits:\n', fg=typer.colors.BRIGHT_GREEN, bold=True, underline=True)
+
+            final_str += self._single_data
+
+        if len(self._multiple_data) > 0:
+            final_str += typer.style('\n+++ ', fg=typer.colors.GREEN)
+            final_str += typer.style('Linting your commit history:\n', fg=typer.colors.BRIGHT_GREEN, bold=True, underline=True)
+            
+            final_str += self._multiple_data
+
+        typer.echo(final_str)
+
 
 @app.command()
 def main(upstream: str):
@@ -40,14 +80,20 @@ def main(upstream: str):
     walker.hide(upstream.id)
     walker = tosequence(walker)
 
+    printer = Printer()
+
     for commit in walker:
+        printer.add_commit(commit)
+
         for linter in single_linters:
             lint_result = linter(commit)
             if lint_result.level is not LinterLevel.Empty:
-                print('Commit: {id}'.format(id=commit.id))
-                lint_result.pretty_print()
+                printer.add_single_linter(lint_result)
+
 
     for linter in multi_linters:
         lint_result = linter(walker)
         if lint_result.level is not LinterLevel.Empty:
-            lint_result.pretty_print()
+            printer.add_multiple_linter(lint_result)
+    
+    printer.show()

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
         'typer',
         'pygit2',
         'spacy',
+        'colorama',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Handles color and printing of both single and multiple commit linters.
Ensures that each commit ID is specified only once, with all its single commit linters (that did not turn up empty) listed below it. Commits that are okay are not listed.
Multiple commit linters then follow at the end.

![image](https://user-images.githubusercontent.com/43912285/87687178-0ecaf480-c7a3-11ea-8dfd-aca36e437fde.png)
![image](https://user-images.githubusercontent.com/43912285/87687265-2ace9600-c7a3-11ea-83fd-822719f85d5c.png)
