### PR TITLE
tense_linter: Modify output.

### DIFF
--- a/git_lint_branch/single/tense_linter.py
+++ b/git_lint_branch/single/tense_linter.py
@@ -6,7 +6,7 @@ from git_lint_branch.linter_output import *
 def tense_linter(commit: Commit):
     tab = ' ' * 4
     result = LinterOutput()
-    result.title = 'Tense Linter Output'
+    result.title = 'Commit Message not in Imperative Form'
     past_tenses = []
     doc = NLP(commit.message)
     for sent in doc.sents:
@@ -15,17 +15,17 @@ def tense_linter(commit: Commit):
     if len(past_tenses) == 0:
         result.level = LinterLevel.Empty
         result.message = (
-            f'\n{tab}The commit message is in the present tense.\n'
+            f'\n{tab}The commit message is in the imperative form.\n'
         )
         result.help_string = '\n{tab}Nothing to do here.\n'
         return result
     result.level = LinterLevel.Warning
-    result.message = f'\n{tab}The following words are in past tense:\n'
+    result.message = f'\n{tab}Consider replacing the following words:\n'
     for i, token in enumerate(past_tenses):
-        result.message += f'{tab * 2}{i + 1}. {token} ====> {token.lemma_}\n'
+        result.message += f'{tab * 2}{i + 1}. {token} => {token.lemma_}\n'
     result.help_string = (
         f'\n{tab}If this was the most recent commit, you can edit the message\n'
           f'{tab}with `git commit --amend`. Otherwise, use the reword command in\n'
-          f'an interactive rebase.'
+          f'{tab}an interactive rebase.\n{tab}'
     )
     return result


### PR DESCRIPTION
Had a few issues with newlines and tabs at the end of the suggestions.
Also changed it to say 'imperative form' rather than 'present' and 'past' tense, as that's what's more generally used.